### PR TITLE
fix: automatically include IP addresses in redirect_uris

### DIFF
--- a/src/usr/local/php/unraid-tsidp/prepare-tsidp.php
+++ b/src/usr/local/php/unraid-tsidp/prepare-tsidp.php
@@ -54,6 +54,7 @@ if (file_exists($identFile)) {
 logMessage("Using HTTP port: {$httpPort}, HTTPS port: {$httpsPort}");
 
 $allowedHosts   = getAllowedHosts();
+$allowedHosts   = array_merge($allowedHosts, getIpAddresses());
 $allowedHosts[] = $tailscaleInfo->fqdn;
 $redirect_uris  = [];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended redirect URI validation to automatically incorporate network interface IP addresses alongside existing allowed hosts, broadening the scope of accepted connection sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->